### PR TITLE
Street address on website #203

### DIFF
--- a/public/css/dwyl.css
+++ b/public/css/dwyl.css
@@ -324,7 +324,8 @@ ol li {
       margin-top: 0em;
       margin-bottom: 0;
   }
-  span.contact-detail {
+  .contact-detail { /* used on a mixture of <p> and <span> */
+    margin: 0; /* removes user agent margin on <p> */
     text-align: right;
     width: 100%;
     display: block;

--- a/public/css/dwyl.css
+++ b/public/css/dwyl.css
@@ -479,6 +479,10 @@ ol li {
       font-size: 8em;
       margin-top: -2em;
   }
+  div.contact-info {
+    max-width: 24em;
+    float: right;
+  }
   .values h1 {
     margin-bottom: 2.5em;
   }

--- a/views/index.html
+++ b/views/index.html
@@ -136,7 +136,12 @@
       <div class="contact-info">
         <span class="contact-detail">Tel: <a href="tel:07708796446">07708796446</a></span>
         <span class="contact-detail">Email: <a href="mailto:hello@dwyl.io">hello@dwyl.io</a></span>
-        <span class="contact-detail">Address: <a href="https://www.google.co.uk/maps/place/16+Palmers+Rd,+London+E2+0SY/@51.5294086,-0.0444392,17z/data=!4m13!1m7!3m6!1s0x48761d2695efb1b1:0x30455a5f7ce8535d!2s16+Palmers+Rd,+London+E2+0SY!3b1!8m2!3d51.5294086!4d-0.0422505!3m4!1s0x48761d2695efb1b1:0x30455a5f7ce8535d!8m2!3d51.5294086!4d-0.0422505">16 Palmers Road, London E2 0SY</a></span>
+        <p class="contact-detail adr">Address: <a href="https://www.google.co.uk/maps/place/16+Palmers+Rd,+London+E2+0SY" target="_blank">
+          <span class="street-address">16 Palmers Road</span>,
+          <span class="locality">London</span>,
+          <span class="postal-code">E2 0SY</span>
+          <span class="country-name">U.K.</span>
+        </a></p>
         <span class="contact-tagline"> We'll get back to you within 24 hours. </span>
       </div>
     </div>
@@ -189,7 +194,7 @@
   <!-- This needs an additional class of dark-bg when 'What our clients say' gets added -->
   <div class="copyright-block">
     <p>
-      Copyright 2016 &copy; dwyl ltd, company number 09525434 registered in England &amp; Wales. at 104 Mary Datchelor Close, London SE5 7DY, UK. All rights reserved.
+      Copyright 2016 &copy; dwyl ltd, company number 09525434 registered in England &amp; Wales at 104 Mary Datchelor Close, London SE5 7DY, UK. All rights reserved.
     </p>
     <p>
       <i>We fully support the <a href="http://www.chagossupport.org.uk/">Chagossians</a> and their right to claim profits from the sale of .io domains associated with their homeland.</i>

--- a/views/index.html
+++ b/views/index.html
@@ -136,6 +136,7 @@
       <div class="contact-info">
         <span class="contact-detail">Tel: <a href="tel:07708796446">07708796446</a></span>
         <span class="contact-detail">Email: <a href="mailto:hello@dwyl.io">hello@dwyl.io</a></span>
+        <span class="contact-detail">Address: <a href="https://www.google.co.uk/maps/place/16+Palmers+Rd,+London+E2+0SY/@51.5294086,-0.0444392,17z/data=!4m13!1m7!3m6!1s0x48761d2695efb1b1:0x30455a5f7ce8535d!2s16+Palmers+Rd,+London+E2+0SY!3b1!8m2!3d51.5294086!4d-0.0422505!3m4!1s0x48761d2695efb1b1:0x30455a5f7ce8535d!8m2!3d51.5294086!4d-0.0422505">16 Palmers Road, London E2 0SY</a></span>
         <span class="contact-tagline"> We'll get back to you within 24 hours. </span>
       </div>
     </div>
@@ -188,7 +189,7 @@
   <!-- This needs an additional class of dark-bg when 'What our clients say' gets added -->
   <div class="copyright-block">
     <p>
-      Copyright 2016 &copy; dwyl ltd, company number 09525434, registered in England &amp; based at 104 Mary Datchelor Close, London SE5 7DY, UK. All rights reserved.
+      Copyright 2016 &copy; dwyl ltd, company number 09525434 (registered in England at 104 Mary Datchelor Close, London SE5 7DY, UK). All rights reserved.
     </p>
     <p>
       <i>We fully support the <a href="http://www.chagossupport.org.uk/">Chagossians</a> and their right to claim profits from the sale of .io domains associated with their homeland.</i>


### PR DESCRIPTION
Original Issue
https://github.com/dwyl/dwyl-site/issues/203

Adds the bricks and mortar address to the front page in large type next to telephone and email address. 

Retains registered address in footer. 