### PR TITLE
Custom domains for heroku apps

### DIFF
--- a/heroku-custom-domain.md
+++ b/heroku-custom-domain.md
@@ -1,0 +1,18 @@
+# How create a custom domain for a heroku app
+
+1. Add custom domain to heroku:
+  + Install heroku CLI
+  + `heroku login`
+  + `heroku apps`
+  + `heroku apps:info --app cul-app`
+  + `heroku domains --app cul-app`
+  + `heroku domains:add --app cul-app www.quodl.uk`
+  + `heroku domains --app cul-app`
+
+For teams, must have admin rights, (can't just be a team member), easier to do it on heroku UI.
+
+2. In your domain name provider, alter the `CNAME` record to point to your herokuapp:
+  + Go to 'Manage DNS records'
+  + Create a `CNAME` record with the name `www` pointing to the herokuapp
+
+![image](https://cloud.githubusercontent.com/assets/16817089/23122083/ba078506-f75a-11e6-87f5-4c2361a8e8f8.png)


### PR DESCRIPTION
Adds instructions for adding a custom domain for a herokuapp. #207 

These are just the barebones and still need a lot of work:
+ Why? What?
+ Screenshots
+ Explanation of what is happening around the bullet points
+ Understanding whether the CNAME should be pointing to just the herokuapp url as it does with dwyl.io or whether it should have the target DNS provided by heroku (in this case www.quodl.co.uk.herokudns.com)
+ Discussion of application configurations and SSL certificates which has been giving us the biggest headache until now
+ Swapping out this example for healthlocker

Reference issues https://github.com/cul-2016/quiz/issues/374 for cul-app.