### PR TITLE
makes link dim on hover

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -35,7 +35,7 @@
     <link rel="manifest" href="/img/manifest.json">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="/img/ms-icon-144x144.png">
-    <meta name="theme-color" content="#ffffff">  
+    <meta name="theme-color" content="#ffffff">
     <title>The Blog | Web Development, Agile Methodologies and more | dwyl</title>
   </head>
   <body>
@@ -70,8 +70,8 @@
       <h1 class="dwyl-mint f2 tc">The dwyl Blog</h1>
       <div class="mw8 center ph0 ph3-ns">
       <div class="w-50-ns w-25-l w-90 pt3 ph3 ph3-ns pb3 dib-ns dtc-ns v-top center white">
-        <a href="/blog/2017/september/welcome" class="link white">
-          <h3 class="f4">Welcome to Our New Site</h3>
+        <a href="/blog/2017/september/welcome" class="white f4 dim link">
+          Welcome to Our New Site
         </a>
         <p class="f6">
           We've given our site a fresh design. Find out what inspired us and


### PR DESCRIPTION
Adds a dim on the link to the blog post on the `/blog` page on hover and focus, in an attempt to make the link more obvious.

#380