### PR TITLE
adds shadow to cookie notification

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
         <img src="/img/common/dwyl-grey-heart.png" alt="dwyl heart logo" class="pv4">
     </footer>
 
-    <section id="cookie-notification" class="w-100 dwyl-bg-dark-gray bottom-0 fixed h-auto tc-ns tl ph4-ns pt3-ns pb2-ns pt3 ph3 ">
+    <section id="cookie-notification" class="w-100 dwyl-bg-dark-gray bottom-0 fixed h-auto tc-ns tl ph4-ns pt3-ns pb2-ns pt3 ph3 shadow-3">
     <p class="white di f4-ns">This site uses cookies to improve your experience, your
     continued use is considered to be consent. <span class="yes-script">Click this button to not see
     this message again</span><noscript>This message will continue to show, as you have Javascript disabled.</noscript></p>


### PR DESCRIPTION
Adds shadow to define cookie notification more. 

My screen: 
![app website and software development training london dwyl - google chrome_048](https://user-images.githubusercontent.com/21139983/31335418-71b20150-acea-11e7-8989-5847ac20c157.png)

Mimicked smaller screen:
![app website and software development training london dwyl - google chrome_050](https://user-images.githubusercontent.com/21139983/31335419-71ca0700-acea-11e7-93f3-aac424917579.png)



#427