### PR TITLE
Missing space in title

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="/img/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
-    <title>App, Website and Software Development & Training| London | dwyl</title>
+    <title>App, Website and Software Development & Training | London | dwyl</title>
   </head>
   <body class="dwyl-bg-dark-gray">
     <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
No space before | pipe. It's so upsetting I can't visit the site till it's fixed

![image](https://user-images.githubusercontent.com/11595920/33432436-cb5da3a4-d5cf-11e7-96e7-7ab1627d2fe7.png)
