### PR TITLE
Removes mention of FocusHub

### DIFF
--- a/values.html
+++ b/values.html
@@ -112,8 +112,7 @@
             Our people are our primary focus, not profit. We have a
             <a href="/community" class="dwyl-yellow">worldwide community of over 400 creative technologists.</a>
             We believe in inclusivity and accessibility and want to enrich the
-            lives of everyone in our community. That’s why we made
-            <a href="https://www.focushub.co.uk/" class="dwyl-yellow">a home for our London-based team at Focus Hub.</a>
+            lives of everyone in our community.
           </p>
         </div>
         <div class="dib w-45-ns ml0-m ml5-ns v-top pb4-ns pb0">


### PR DESCRIPTION
Alerted to this by the recent email inquiry - removes mention of and link to now-defunct FocusHub website

Answers #468